### PR TITLE
fix bad formatting

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -6,7 +6,7 @@ permalink: /contact/
 
 AtomVM users and developers can be found on the [AtomVM Forum](https://erlangforums.com/c/erlang-platforms/atomvm-forum/76).
 
-We have an active Telegram community dicussing [AtomVM - Erlang and Elixir on Microcontrollers 🏝].)(https://t.me/atomvm)
+We have an active Telegram community dicussing [AtomVM - Erlang and Elixir on Microcontrollers 🏝](https://t.me/atomvm).
 We also hang out on the [AtomVM Discord](https://discord.gg/QA7fNjm9Nw) channel.
 
 Drop in and say hello!


### PR DESCRIPTION
there was a mistake that caused the Telegram chat link to not be rendered correctly.