### PR TITLE
Fix download link

### DIFF
--- a/download.md
+++ b/download.md
@@ -6,7 +6,7 @@ permalink: /download/
 
 # Release 0.5.0
 
-* [atomvm-esp32-0.5.0.img](https://atomvm.net/downloads/atomvm-esp32-0.5.0.img)
+* [atomvm-esp32-0.5.0.img](https://github.com/atomvm/AtomVM/releases/download/v0.5.0/AtomVM-v0.5.0-ESP32.img)
     * MD5: `291872d5c72786a35b264d05ed0fd5b0`
     * SHA256: `46818d125ba2c2e4636be7e6dcdac914baa36facc258a948d695572b7083b5ab`
 


### PR DESCRIPTION
Fix esp32 0.5.0 release image url to point to download link on github release page.