### PR TITLE
Update `doc` URL

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,9 @@ jobs:
           path: ./www
 
       - name: Build Site
-        run: /home/runner/.local/share/gem/ruby/3.0.0/bin/bundle exec jekyll build -d www
+        run: |
+          /home/runner/.local/share/gem/ruby/3.0.0/bin/bundle exec jekyll build -d www
+          touch www/.nojekyll
 
       - name: Commit files
         working-directory: ./www

--- a/_config.yml
+++ b/_config.yml
@@ -45,7 +45,7 @@ theme: moonwalk
 plugins:
   - jekyll-feed
 
-keep_files: [CNAME, .git]
+keep_files: [CNAME, .git, .nojekyll, doc]
 
 # Exclude from processing.
 # The following items will not be processed, by default.

--- a/_data/home.yml
+++ b/_data/home.yml
@@ -6,7 +6,7 @@ navbar_entries:
     url: news
 
   - title: doc
-    url: https://doc.atomvm.net
+    url: doc/master
 
   - title: github
     url: https://github.com/atomvm
@@ -22,7 +22,7 @@ navbar_entries:
 
 project_entries:
   - title: Documentation
-    url: https://doc.atomvm.net
+    url: doc/master
     desc: AtomVM documentation, from soup to nuts.  Everything you want to know about AtomVM!
 
   - title: Sample Code


### PR DESCRIPTION
Changes the location of `doc` from the remote https://doc.atomvm.net to the local /doc/${branch} where the content created from AtomVM/docs and API is updated automatically by a separate workflow in the AtomVM repo. Chanes workflow to accommodate styles and content added by the AtomVM repository Publish Docs workflow.