### PR TITLE
Fix workflow for forks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,6 +64,7 @@ jobs:
           touch www/.nojekyll
 
       - name: Commit files
+        if: github.repository == 'atomvm/atomvm_www'
         working-directory: ./www
         run: |
           git checkout Production


### PR DESCRIPTION
Prevents forks from attempting to run the `publish` action after a successful build.