### PR TITLE
Fix bug in workflow in personal forks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,6 +74,7 @@ jobs:
           git add .
           git commit -m "Update Documentation"
       - name: Push changes
+        if: github.repository == 'atomvm/atomvm_www'
         working-directory: ./www
         run: |
           eval `ssh-agent -t 60 -s`


### PR DESCRIPTION
Adds a missing repository check to the Publish job, to prevent attempting to push changes when run in a fork.