### PR TITLE
Add atom news feed for news articles and announce master branch rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,26 @@ Serve up your site!
 or build the website:
 
     bundle exec jekyll build [-d <path-to-output>] [--watch]
+
+# Add a News Post
+
+To post a new article add a file to the _posts directory in the format:
+
+`YYYY-MM-DD-{title}.md`
+
+with a title section like:
+
+```
+---
+layout: post
+title: {Your Headline}
+excerpt_separator: <!--more-->
+---
+```
+
+followed by the news post in markdown format.
+If you are posting a long article you can tell where to cut off the introduction that is displayed in the news section, leaving the full article available by following the article link, by placing a line containing:
+
+`<!--more-->`
+
+All content following the above line will only be included in the full article, content before will be displayed as a description on the `atomvm.net/news` page.

--- a/_config.yml
+++ b/_config.yml
@@ -27,9 +27,8 @@ description: >- # this means to ignore newlines until "baseurl:"
 # line in _config.yml. It will appear in your document head meta (for
 # Google search results) and in your feed.xml site description.
 #baseurl: "/" # the subpath of your site, e.g. /blog
-url: "https://www.atomvm.net/" # the base hostname & protocol for your site, e.g. http://example.com
-twitter_username: jekyllrb
-github_username:  jekyll
+url: "https://www.atomvm.net" # the base hostname & protocol for your site, e.g. http://example.com
+github_username:  atomvm
 
 host: "www.atomvm.net"
 

--- a/_posts/2023-12-10-old_news.md
+++ b/_posts/2023-12-10-old_news.md
@@ -1,0 +1,90 @@
+---
+layout: post
+title: Previous Announcements
+excerpt_separator: <!--more-->
+---
+
+## 2023/12/10 Announcing AtomVM v0.6.0-alpha.2 (Pre-release)
+
+This pre-release has a build dependency change from OpenSSL to one on [Mbed-TLS](https://www.trustedfirmware.org/projects/mbed-tls/) to provide cryptographic functions for the generic_unix platform.
+
+Numerous bugs have been fixed since the last release including where guards would raise exceptions instead of just being false, precision of integers used with timers which could yield to halts and wait times smaller than expected, and big endian CPUs are working again.
+
+New features include the introduction of OTP socket interface support, support for `net:getaddrinfo/1,2`, minimal OTP `ssl` interface support, `crypto:strong_rand_bytes/1` using Mbed-TLS on generic_unix, ESP32 and RP2040 platforms, support for `crypto:one_time/4,5` on Unix and Pico as well as for `crypto:hash/2` on Pico. Improvements for the STM32 platform include complete device configuration without the need to edit hardcoded values in the source files, complete GPIO driver support, and improved performance by enabling flash cache and i-cache.
+
+For the full set of bug fixes, changes and additions consult the [Changelog](https://www.atomvm.net/doc/v0.6.0-alpha.2/CHANGELOG.html).
+
+Download images and binaries are available for most platforms, except STM32 (and some generic_unix hosts for this release due to specific Mbed-TLS requirements) are available from [AtomVM Releases on GitHub](https://github.com/atomvm/AtomVM/releases/tag/v0.6.0-alpha.2). STM32 users as well as anyone needing to build a generic_unix port for a device without release binaries should consult the [Build Instructions](https://www.atomvm.net/doc/v0.6.0-alpha.2/build-instructions.html).
+
+The git repository and tarballs of the AtomVM source release for all platforms can be found on our [GitHub AtomVM page](https://github.com/atomvm/AtomVM).
+
+Documentation for the v0.6.0-alpha.2 pre-release of the AtomVM virtual machine, including a Getting Started Guide, can be found at the [AtomVM Documentation page](https://www.atomvm.net/doc/v0.6.0-alpha.2/).
+
+As always, tools, drivers, and modules are available on the [GitHub AtomVM Project page](https://github.com/atomvm).
+
+Many thanks go to [Davide Bettio](https://github.com/bettio), for creating such a fine work of software, as well as the [contributors](https://github.com/atomvm/AtomVM/graphs/contributors) and [testers who have helped make this release possible](https://github.com/atomvm/AtomVM/issues).
+
+The AtomVM team
+
+## 2023/10/09 Announcing AtomVM v0.6.0-alpha.1 (Pre-release)
+
+This is a follow up to the recent v0.6.0-alpha.0 release that fixes some bugs and adds a few new features.
+
+The ESP32 port gains support for ULP wakeup, and expands crypto support. Basic wifi support has been added for the RPi Pico W. There is now the ability to select from heap growth strategies as a fine-tuning option to `spawn_opt/2,4`. Several platforms now have the ability to set the system clock with `atomvm:posix_clock_settime/2`. A few more standard Erlang functions have been added to the core libraries as well. For a complete list of all the changes consult the [Changelog](https://www.atomvm.net/doc/v0.6.0-alpha.1/CHANGELOG.html).
+
+Download images and binaries are available for most platforms (for now stm32 ports must be build locally) are available from [AtomVM Releases on GitHub](https://github.com/atomvm/AtomVM/releases/tag/v0.6.0-alpha.1).
+
+The git repository and tarballs of the AtomVM source release for all platforms can be found on our [GitHub AtomVM page](https://github.com/atomvm/AtomVM).
+
+Documentation for the v0.6.0-alpha.1 pre-release of the AtomVM virtual machine, including a Getting Started Guide, can be found at the [AtomVM Documentation page](https://www.atomvm.net/doc/v0.6.0-alpha.1/).
+
+We have a growing collection of tools, drivers, and modules available on the [GitHub AtomVM Project page](https://github.com/atomvm).
+
+Many thanks go to [Davide Bettio](https://github.com/bettio), for creating such a fine work of software, as well as the [contributors](https://github.com/atomvm/AtomVM/graphs/contributors) and [testers who have helped make this release possible](https://github.com/atomvm/AtomVM/issues).
+
+The AtomVM team
+
+## 2023/09/01 Announcing AtomVM v0.6.0-alpha.0 (Pre-release)
+
+After many months of work, we are happy to announce a pre-release of v0.6.0-alpha.0 of the AtomVM virtual machine, a lightweight implementation of the BEAM for small and cheap micro-controllers!
+
+This pre-view contains many improvements and bug fixes that the AtomVM team has been working on, including SMP support on all multi-core platforms, support for the ESP32-S3, ESP32-C3, and ESP32-S2 chips, and the addition of a very basic rp2040 (a.k.a. Raspberry Pi Pico) port, as well as an emscripten port using nodejs with Wasm to run AtomVM in the browser. See the [Changelog](https://www.atomvm.net/doc/v0.6.0-alpha.0/CHANGELOG.html) for all the improvements, bug fixes, and breaking changes since the 0.5.0 release.
+
+Download images for the ESP32 family are available on the [AtomVM Releases GitHub page](https://github.com/atomvm/AtomVM/releases). Other platforms should consult the [Build Instructions](https://www.atomvm.net/doc/v0.6.0-alpha.0/build-instructions.html) for the
+v0.6.0-alpha.0 release.
+
+The git repository and tarballs of the AtomVM source release for all platforms can be found on our [GitHub AtomVM page](https://github.com/atomvm/AtomVM).
+
+Documentation for the v0.6.0-alpha.0 pre-release of the AtomVM virtual machine, including a Getting Started Guide, can be found at the [AtomVM Documentation page](https://www.atomvm.net/doc/v0.6.0-alpha.0/).
+
+We have a growing collection of tools, drivers, and modules available on the [GitHub AtomVM Project page](https://github.com/atomvm).
+
+Many thanks go to [Davide Bettio](https://github.com/bettio), for creating such a fine work of software, as well as the [contributors](https://github.com/atomvm/AtomVM/graphs/contributors) and [testers who have helped make this release possible](https://github.com/atomvm/AtomVM/issues?q=is%3Aissue+is%3Aclosed).
+
+The AtomVM team
+
+## 2022/04/05 AtomVM Example Programs
+
+We have extracted our example programs into a self-contained and growing github repo with minimal dependencies. For example, if you have flashed the AtomVM image to an ESP32 device, you can simply use rebar3 to build and flash your applications, making the compile/flash/debug cycle you experience on embedded devices fairly painless.
+
+[AtomVM Example Programs](https://github.com/atomvm/atomvm_examples)
+
+Please note that at this stage, support for building Elixir programs is quite far behind that of Erlang, so best to stick with Erlang until further notice.
+
+<!--more-->
+
+## 2022/03/22 Announcing AtomVM 0.5.0
+
+After many months of work, we are happy to announce version 0.5.0 of the AtomVM virtual machine, a lightweight implementation of the BEAM for small and cheap micro-controllers!
+
+This release of AtomVM is our first development preview release. We are still shaking out some of the rough edges, but we feel the release is stable enough for intrepid developers to get started with simple Erlang or Elixir programs.
+
+A binary image of ESP32 release can be found in the [download](https://atomvm.net/download/) section of the AtomVM [web page](https://atomvm.net/).
+
+The git repository and tarballs of the AtomVM source release for all other platforms can be found on our [GitHub project page](https://github.com/atomvm).
+
+Documentation of the AtomVM virtual machine, including a Getting Started Guide, can be found at the [AtomVM Documentation page](https://doc.atomvm.net/index.html)
+
+Many thanks go to Davide Bettio, for creating such a fine work of software, as well as the contributors and testers who have helped make this release possible.
+
+The AtomVM team

--- a/_posts/2024-02-22-master_branch_renamed.md
+++ b/_posts/2024-02-22-master_branch_renamed.md
@@ -1,0 +1,24 @@
+---
+layout: post
+title: AtomVM `master` branch renamed
+excerpt_separator: <!--more-->
+---
+
+## 2024/02/22 Recent updates to the name of the `master` branch.
+
+Earlier this month the name of the [AtomVM](https://github.com/atomvm/AtomVM) `master` branch was renamed to `main`.  If you have previously made a local clone of the repository, and would like to keep up to date with changes to the `main` branch, there are a few `git` commands that will rename your local copy and update the git configuration to track the `main` AtomVM branch on GitHub.
+
+From inside your local clone of [AtomVM](https://github.com/atomvm/AtomVM):
+
+    shell$ git branch -m master main
+    shell$ git fetch origin
+    shell$ git branch -u origin/main main
+    shell$ git remote set-head origin -a
+
+At this point you now have a local clone that will stay up to date with changes in the upstream AtomVM `main` branch.
+
+We have also recently created the `release-0.6` branch, which should be used if you wish to contribute any bug fixes.  If you do find a bug, please open an [issue on GitHub](https://github.com/atomvm/AtomVM/issues).
+
+If you encounter a feature you think we are lacking, please [open an issue](https://github.com/atomvm/AtomVM/issues) for that too.  Any contributions of new features should be made on the `main` branch.
+
+The AtomVM team

--- a/news.md
+++ b/news.md
@@ -1,87 +1,20 @@
 ---
-layout: post
+layout: default
 title: News
 permalink: /news/
 ---
-## 2023/12/10 Announcing AtomVM v0.6.0-alpha.2 (Pre-release)
 
-This pre-release has a build dependency change from OpenSSL to one on [Mbed-TLS](https://www.trustedfirmware.org/projects/mbed-tls/) to provide cryptographic functions for the generic_unix platform.
+<!--
+See README.md for instructions on adding a news post
+-->
 
-Numerous bugs have been fixed since the last release including where guards would raise exceptions instead of just being false, precision of integers used with timers which could yield to halts and wait times smaller than expected, and big endian CPUs are working again.
+<a href="/index.html">home..</a>
 
-New features include the introduction of OTP socket interface support, support for `net:getaddrinfo/1,2`, minimal OTP `ssl` interface support, `crypto:strong_rand_bytes/1` using Mbed-TLS on generic_unix, ESP32 and RP2040 platforms, support for `crypto:one_time/4,5` on Unix and Pico as well as for `crypto:hash/2` on Pico. Improvements for the STM32 platform include complete device configuration without the need to edit hardcoded values in the source files, complete GPIO driver support, and improved performance by enabling flash cache and i-cache.
-
-For the full set of bug fixes, changes and additions consult the [Changelog](https://www.atomvm.net/doc/v0.6.0-alpha.2/CHANGELOG.html).
-
-Download images and binaries are available for most platforms, except STM32 (and some generic_unix hosts for this release due to specific Mbed-TLS requirements) are available from [AtomVM Releases on GitHub](https://github.com/atomvm/AtomVM/releases/tag/v0.6.0-alpha.2). STM32 users as well as anyone needing to build a generic_unix port for a device without release binaries should consult the [Build Instructions](https://www.atomvm.net/doc/v0.6.0-alpha.2/build-instructions.html).
-
-The git repository and tarballs of the AtomVM source release for all platforms can be found on our [GitHub AtomVM page](https://github.com/atomvm/AtomVM).
-
-Documentation for the v0.6.0-alpha.2 pre-release of the AtomVM virtual machine, including a Getting Started Guide, can be found at the [AtomVM Documentation page](https://www.atomvm.net/doc/v0.6.0-alpha.2/).
-
-As always, tools, drivers, and modules are available on the [GitHub AtomVM Project page](https://github.com/atomvm).
-
-Many thanks go to [Davide Bettio](https://github.com/bettio), for creating such a fine work of software, as well as the [contributors](https://github.com/atomvm/AtomVM/graphs/contributors) and [testers who have helped make this release possible](https://github.com/atomvm/AtomVM/issues).
-
-The AtomVM team
-
-## 2023/10/09 Announcing AtomVM v0.6.0-alpha.1 (Pre-release)
-
-This is a follow up to the recent v0.6.0-alpha.0 release that fixes some bugs and adds a few new features.
-
-The ESP32 port gains support for ULP wakeup, and expands crypto support. Basic wifi support has been added for the RPi Pico W. There is now the ability to select from heap growth strategies as a fine-tuning option to `spawn_opt/2,4`. Several platforms now have the ability to set the system clock with `atomvm:posix_clock_settime/2`. A few more standard Erlang functions have been added to the core libraries as well. For a complete list of all the changes consult the [Changelog](https://www.atomvm.net/doc/v0.6.0-alpha.1/CHANGELOG.html).
-
-Download images and binaries are available for most platforms (for now stm32 ports must be build locally) are available from [AtomVM Releases on GitHub](https://github.com/atomvm/AtomVM/releases/tag/v0.6.0-alpha.1).
-
-The git repository and tarballs of the AtomVM source release for all platforms can be found on our [GitHub AtomVM page](https://github.com/atomvm/AtomVM).
-
-Documentation for the v0.6.0-alpha.1 pre-release of the AtomVM virtual machine, including a Getting Started Guide, can be found at the [AtomVM Documentation page](https://www.atomvm.net/doc/v0.6.0-alpha.1/).
-
-We have a growing collection of tools, drivers, and modules available on the [GitHub AtomVM Project page](https://github.com/atomvm).
-
-Many thanks go to [Davide Bettio](https://github.com/bettio), for creating such a fine work of software, as well as the [contributors](https://github.com/atomvm/AtomVM/graphs/contributors) and [testers who have helped make this release possible](https://github.com/atomvm/AtomVM/issues).
-
-The AtomVM team
-
-## 2023/09/01 Announcing AtomVM v0.6.0-alpha.0 (Pre-release)
-
-After many months of work, we are happy to announce a pre-release of v0.6.0-alpha.0 of the AtomVM virtual machine, a lightweight implementation of the BEAM for small and cheap micro-controllers!
-
-This pre-view contains many improvements and bug fixes that the AtomVM team has been working on, including SMP support on all multi-core platforms, support for the ESP32-S3, ESP32-C3, and ESP32-S2 chips, and the addition of a very basic rp2040 (a.k.a. Raspberry Pi Pico) port, as well as an emscripten port using nodejs with Wasm to run AtomVM in the browser. See the [Changelog](https://www.atomvm.net/doc/v0.6.0-alpha.0/CHANGELOG.html) for all the improvements, bug fixes, and breaking changes since the 0.5.0 release.
-
-Download images for the ESP32 family are available on the [AtomVM Releases GitHub page](https://github.com/atomvm/AtomVM/releases). Other platforms should consult the [Build Instructions](https://www.atomvm.net/doc/v0.6.0-alpha.0/build-instructions.html) for the
-v0.6.0-alpha.0 release.
-
-The git repository and tarballs of the AtomVM source release for all platforms can be found on our [GitHub AtomVM page](https://github.com/atomvm/AtomVM).
-
-Documentation for the v0.6.0-alpha.0 pre-release of the AtomVM virtual machine, including a Getting Started Guide, can be found at the [AtomVM Documentation page](https://www.atomvm.net/doc/v0.6.0-alpha.0/).
-
-We have a growing collection of tools, drivers, and modules available on the [GitHub AtomVM Project page](https://github.com/atomvm).
-
-Many thanks go to [Davide Bettio](https://github.com/bettio), for creating such a fine work of software, as well as the [contributors](https://github.com/atomvm/AtomVM/graphs/contributors) and [testers who have helped make this release possible](https://github.com/atomvm/AtomVM/issues?q=is%3Aissue+is%3Aclosed).
-
-The AtomVM team
-
-## 2022/04/05 AtomVM Example Programs
-
-We have extracted our example programs into a self-contained and growing github repo with minimal dependencies. For example, if you have flashed the AtomVM image to an ESP32 device, you can simply use rebar3 to build and flash your applications, making the compile/flash/debug cycle you experience on embedded devices fairly painless.
-
-[AtomVM Example Programs](https://github.com/atomvm/atomvm_examples)
-
-Please note that at this stage, support for building Elixir programs is quite far behind that of Erlang, so best to stick with Erlang until further notice.
-
-## 2022/03/22 Announcing AtomVM 0.5.0
-
-After many months of work, we are happy to announce version 0.5.0 of the AtomVM virtual machine, a lightweight implementation of the BEAM for small and cheap micro-controllers!
-
-This release of AtomVM is our first development preview release. We are still shaking out some of the rough edges, but we feel the release is stable enough for intrepid developers to get started with simple Erlang or Elixir programs.
-
-A binary image of ESP32 release can be found in the [download](https://atomvm.net/download/) section of the AtomVM [web page](https://atomvm.net/).
-
-The git repository and tarballs of the AtomVM source release for all other platforms can be found on our [GitHub project page](https://github.com/atomvm).
-
-Documentation of the AtomVM virtual machine, including a Getting Started Guide, can be found at the [AtomVM Documentation page](https://doc.atomvm.net/index.html)
-
-Many thanks go to Davide Bettio, for creating such a fine work of software, as well as the contributors and testers who have helped make this release possible.
-
-The AtomVM team
+<ul>
+  {% for post in site.posts %}
+    <li>
+      <a href="{{ post.url }}">{{ post.title }}</a>
+      {{ post.excerpt }}
+    </li>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
The way the content of the `news` page is generated has been changed to support syndicating news article via an atom feed.  Rather than including flat content from `news.md`, the page is generated from the contents of files in the `_posts` directory. These files must be named in the form:

`YYYY-MM-DD-{title}.md`

and begin with a title section like:
```
---
layout: post
title: {Your Headline}
---
```

The news articles should be formatted in markdown. When new article posts are published they will immediately be available for newsreaders subscribed to the atom feed. (no pun intended, but kind of beautiful the way that works out)

All previous news articles are included in a single post, and a new  announcement about the rename of the AtomVM `master` branch, with instructions for keeping local clones of the repo up to date.