### PR TITLE
Update doc url to reflect AtomVM branch rename

### DIFF
--- a/_data/home.yml
+++ b/_data/home.yml
@@ -6,7 +6,7 @@ navbar_entries:
     url: news
 
   - title: doc
-    url: doc/master
+    url: doc/main
 
   - title: github
     url: https://github.com/atomvm


### PR DESCRIPTION
Changes the doc url to piont to `main`, to reflect the recent name change of the `master` branch of AtomVM.