### PR TITLE
Add post template

### DIFF
--- a/_posts/YYYY-MM-DD-short_article_title.md.template
+++ b/_posts/YYYY-MM-DD-short_article_title.md.template
@@ -1,0 +1,14 @@
+---
+layout: post
+title: {{Article Title}}
+author: {{The AtomVM Team}}
+excerpt_separator: <!--more-->
+---
+
+## {YYYY/MM/DD} (optional - mainly for announcements) {Your article title}
+
+Your announcement or introductory paragraph (for articles or longer posts)
+
+<!--more-->
+
+The rest of a longer article continues here. Anything below the above "more" tag will not appear on the atomvm.net/news page, or feed reader news feed, but the full article can be read by following the article link that will appear on the news page or in a feed reader.


### PR DESCRIPTION
Adds a template file that needs to be renamed accordingly, and the appropriate information and content replaced with a news post or article.