### PR TITLE
Chang default documentation branch

### DIFF
--- a/_data/home.yml
+++ b/_data/home.yml
@@ -22,7 +22,7 @@ navbar_entries:
 
 project_entries:
   - title: Documentation
-    url: doc/master
+    url: doc/stable
     desc: AtomVM documentation, from soup to nuts.  Everything you want to know about AtomVM!
 
   - title: Sample Code


### PR DESCRIPTION
Changed the default documentation branch to `stable` which is a symlink that points to the latest stable release.

This should be merged after #29