### PR TITLE
Remove emoji that didnt render

### DIFF
--- a/_posts/2024-07-22-Release_v0.6.3.md
+++ b/_posts/2024-07-22-Release_v0.6.3.md
@@ -66,8 +66,8 @@ As always, tools, drivers, and modules are available on the
 
 Many thanks go to [Davide Bettio](https://github.com/bettio), for creating and maintaining such a
 fine work of software. Special thanks also to [takasehideki](https://github.com/takasehideki) and
-[Mikael Karlsson](https://github.com/karlsson) for their first contributions to the project :tada ,
-along with the rest of the  [contributors](https://github.com/atomvm/AtomVM/graphs/contributors) and
+[Mikael Karlsson](https://github.com/karlsson) for their first contributions to the project, along
+with the rest of the  [contributors](https://github.com/atomvm/AtomVM/graphs/contributors) and
 [testers who have helped make this release possible](https://github.com/atomvm/AtomVM/issues).
 
 The AtomVM team


### PR DESCRIPTION
The release announcement for v0.6.3 contained an emoji that didn't render, this commit remove it.