### PR TITLE
AtomVM v0.6.5 MacOS updates

### DIFF
--- a/_posts/2024-10-15-AtomVM_v0.6.5_MacOS.md
+++ b/_posts/2024-10-15-AtomVM_v0.6.5_MacOS.md
@@ -1,0 +1,32 @@
+---
+layout: post
+title: AtomVM v0.6.5 for MacOS
+excerpt_separator: <!--more-->
+---
+
+## 2024/10/15 AtomVM v0.6.5 MacOS update options
+
+Updates for MacOS through `macports` and `homebrew` are now available for AtomVM v0.6.5. For first time installation see the [MacOS installation section](https://www.atomvm.net/doc/v0.6.5/getting-started-guide.html#installation-on-macos) of the [Getting Started Guide](https://www.atomvm.net/doc/v0.6.5/getting-started-guide.html).
+
+To upgrade a previously tapped `homebrew`  install use:
+
+    $ brew update
+    $ brew upgrade atomvm
+
+To upgrade an install from `macports` 
+
+    $ sudo port selfupdate
+    $ sudo port upgrade outdated
+
+For all the details about the AtomVM v0.6.5 release see the [release announcement](https://www.atomvm.net/2024/10/14/Release_v0.6.5.html).
+
+Documentation for the v0.6.5 release of the AtomVM virtual machine, including a
+[Getting Started Guide](https://www.atomvm.net/doc/v0.6.5/getting-started-guide.html), can be found in the
+[AtomVM Documentation](https://www.atomvm.net/doc/v0.6.5/).
+
+To help get you inspired there are examples ready to use with our [`ExAtomVM mix`](https://github.com/atomvm/ExAtomVM) and [`atomvm_rebar3_plugin`](https://github.com/atomvm/atomvm_rebar3_plugin) standard tool plugins in the [AtomVM examples repository](https://github.com/atomvm/atomvm_examples) on GitHub.
+
+Many thanks go to [Davide Bettio](https://github.com/bettio), for creating and maintaining such a
+fine work of software, to [Paul Guyot](https://github.com/pguyot) for maintaining the `macports` release, and to [Peter Madsen-Mygdal](https://github.com/petermm) for maintaining the `homebrew tap`, along with all of their other contributions ;-)
+
+_The AtomVM team_


### PR DESCRIPTION
Announce updates for AtomVM v0.6.5 available for `macports` and `homebrew`.