### PR TITLE
Update contact and domain information

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,18 +19,18 @@
 # in the templates via {{ site.myvariable }}.
 
 title: AtomVM
-email: webmaster@atomvm.net
-author: atomvm.net
+email: atomvm@users.noreply.github.com
+author: atomvm.org
 description: >- # this means to ignore newlines until "baseurl:"
   Welcome to AtomVM, the Erlang virtual machine for IoT devices!
 # Write an awesome description for your new site here. You can edit this
 # line in _config.yml. It will appear in your document head meta (for
 # Google search results) and in your feed.xml site description.
 #baseurl: "/" # the subpath of your site, e.g. /blog
-url: "https://www.atomvm.net" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://atomvm.org" # the base hostname & protocol for your site, e.g. http://example.com
 github_username:  atomvm
 
-host: "www.atomvm.net"
+host: "atomvm.org"
 
 # collections:
 #   portfolio:

--- a/contact.md
+++ b/contact.md
@@ -6,9 +6,6 @@ permalink: /contact/
 
 AtomVM users and developers can be found on the [AtomVM Forum](https://erlangforums.com/c/erlang-platforms/atomvm-forum/76).
 
-We have an active Telegram community dicussing [AtomVM - Erlang and Elixir on Microcontrollers 🏝](https://t.me/atomvm).
-We also hang out on the [AtomVM Discord](https://discord.gg/QA7fNjm9Nw) channel.
+We have an active Telegram community discussing [AtomVM - Erlang and Elixir on Microcontrollers 🏝](https://t.me/atomvm).
 
 Drop in and say hello!
-
-For direct inquiries, please write to us at `help` -at- `atomvm.net`.


### PR DESCRIPTION
Updates the landing page and generated links to use the new atomvm.org domain name. Updates the contact information by removing email link to help@atomvm.net and stop advertising the discord server that we no longer have administrative control over.